### PR TITLE
Make sure threads are counted for unread count instead of messages

### DIFF
--- a/mailbox/js/sync/GoogleMailboxSync.js
+++ b/mailbox/js/sync/GoogleMailboxSync.js
@@ -89,7 +89,7 @@ class GoogleMailboxSync {
 					reject("Local - Mailbox has no email address")
 				} else {
 					let payload = { userId:mailbox.email, q:'label:inbox label:unread', auth:this.auth }
-					gmail.users.messages.list(payload, function(err, response) {
+					gmail.users.threads.list(payload, function(err, response) {
 						if (err) {
 							reject(err)
 						} else {


### PR DESCRIPTION
When you have threads with multiple unread messages, each individual message is counted now.
This fix will count the number of unread threads instead of unread messages (like gmail is also doing).