### PR TITLE
Removed path to webpack binaries - use of tray icon in non-darwin platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "OSX app wrapper for Google Inbox and Google Mail",
   "main": "bin/main/main.js",
   "scripts": {
-    "dev-build": "node node_modules/webpack/bin/webpack.js",
-    "build": "node node_modules/webpack/bin/webpack.js -p",
-    "start": "node node_modules/webpack/bin/webpack.js; electron bin/main/main.js",
+    "dev-build": "webpack",
+    "build": "webpack -p",
+    "start": "webpack; electron bin/main/main.js",
     "package": "node packager.js"
   },
   "keywords": [],

--- a/src/mailbox/ui/App.js
+++ b/src/mailbox/ui/App.js
@@ -1,3 +1,5 @@
+'use strict';
+
 import "./app.less"
 
 const React = require('react')
@@ -9,9 +11,13 @@ const GoogleMailboxWindow = require('./Mailbox/GoogleMailboxWindow')
 const MailboxListItem = require('./Sidelist/MailboxListItem')
 const MailboxListItemAdd = require('./Sidelist/MailboxListItemAdd')
 const Welcome = require('./Welcome/Welcome')
+const path = require('path');
 const ipc = nativeRequire('electron').ipcRenderer;
 const remote = nativeRequire('remote');
 const app = remote.require('app');
+const Tray = remote.require('tray');
+const Menu = remote.require('menu');
+let appTray = null;
 
 module.exports = React.createClass({
 	displayName:'App',
@@ -70,7 +76,17 @@ module.exports = React.createClass({
 
 		// Tell the app about our unread count
 		const unread = store.totalUnreadCount()
-		app.dock.setBadge(unread ? unread.toString() : '')
+		if(process.platform === 'darwin') {
+			app.dock.setBadge(unread ? unread.toString() : '')
+		} else {
+			const unreadText = unread ? unread + ' unread mail' : 'No unread mail';
+			const appIcon = appTray || (appTray = new Tray(path.resolve('icons/app.png')));
+			const contextMenu = Menu.buildFromTemplate([
+				{ label: unreadText}
+			]);
+			appIcon.setToolTip(unreadText);
+			appIcon.setContextMenu(contextMenu);
+		}
 
 		// Return the state update
   	return { mailbox_ids:store.ids() }


### PR DESCRIPTION
Just a little simplification on scripts: modules binaries are automatically linked in node_modules/.bin filder, and npm automatically search binaries in that folder. No need to specify full binaries path.

Also, maybe you could find useful an [example of electron-packager usage here](https://github.com/parro-it/tunnels/blob/master/package.json#L33)