### PR TITLE
removed window close prevention on non-darwin

### DIFF
--- a/src/main/WindowManager.js
+++ b/src/main/WindowManager.js
@@ -33,9 +33,10 @@ class WindowManager {
   handleClose (evt) {
     if (this.focused() && !this.forceQuit) {
       this.contentWindows.forEach(w => w.close())
-      this.mailboxesWindow.hide()
-      evt.preventDefault()
-      this.forceQuit = false
+      if (process.platform === 'darwin') {
+        this.mailboxesWindow.hide()
+        evt.preventDefault()
+      }
     }
   }
 


### PR DESCRIPTION
This prevented correctly app closing on linux platform, they only way to close the app was by killing it via terminal.