### PR TITLE
When selecting to download an update, open the releases page instead of the homepage

### DIFF
--- a/src/main/update.js
+++ b/src/main/update.js
@@ -32,7 +32,7 @@ class Update {
           defaultId: 1
         }, (response) => {
           if (response === 0) {
-            shell.openExternal(constants.GITHUB_URL)
+            shell.openExternal(constants.GITHUB_RELEASES_URL)
           }
         })
       }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -3,6 +3,7 @@ module.exports = Object.freeze({
 
   GITHUB_URL: 'https://github.com/Thomas101/wmail/',
   GITHUB_ISSUE_URL: 'https://github.com/Thomas101/wmail/issues',
+  GITHUB_RELEASES_URL: 'https://github.com/Thomas101/wmail/releases',
   UPDATE_CHECK_URL: 'https://api.github.com/repos/Thomas101/wmail/releases',
 
   GMAIL_PROFILE_SYNC_MS: 1000 * 60 * 30, // 30 mins


### PR DESCRIPTION
This seems like a better experience, to me. Least amount of effort to the user.