### PR TITLE
Linux: Keep app open when closing the window if system tray is visible

### DIFF
--- a/src/mailbox/ui/App.js
+++ b/src/mailbox/ui/App.js
@@ -152,6 +152,9 @@ module.exports = React.createClass({
       ])
       this.appTray.setToolTip(unreadText)
       this.appTray.setContextMenu(contextMenu)
+      this.appTray.on('click', function(e) {
+        ipc.send('focus-app')
+      })
     } else {
       if (this.appTray) {
         this.appTray.destroy()

--- a/src/mailbox/ui/App.js
+++ b/src/mailbox/ui/App.js
@@ -54,6 +54,8 @@ module.exports = React.createClass({
     ipc.on('toggle-sidebar', this.toggleSidebar)
     ipc.on('launch-settings', this.launchSettings)
     ipc.on('download-completed', this.downloadCompleted)
+
+    this.settingsChanged()
   },
 
   componentWillUnmount: function () {

--- a/src/mailbox/ui/App.js
+++ b/src/mailbox/ui/App.js
@@ -152,7 +152,7 @@ module.exports = React.createClass({
       ])
       this.appTray.setToolTip(unreadText)
       this.appTray.setContextMenu(contextMenu)
-      this.appTray.on('click', function(e) {
+      this.appTray.on('click', function (e) {
         ipc.send('focus-app')
       })
     } else {

--- a/src/main/WMailWindow.js
+++ b/src/main/WMailWindow.js
@@ -179,6 +179,13 @@ class WMailWindow extends EventEmitter {
   }
 
   /**
+  * @return true if the window is visible
+  */
+  isVisible () {
+    return this.window.isVisible()
+  }
+
+  /**
   * Sets the download progress
   * @param v: the download progress to set
   */

--- a/src/main/WindowManager.js
+++ b/src/main/WindowManager.js
@@ -86,6 +86,21 @@ class WindowManager {
     }
   }
 
+  /**
+  * Focuses the main mailboxes window and shows it if it's hidden
+  */
+  focusMailboxesWindow () {
+    if (this.focused()) {
+      // If there's already a focused window, do nothing
+      return
+    }
+
+    if (!this.mailboxesWindow.isVisible()) {
+      this.mailboxesWindow.show()
+    }
+    this.mailboxesWindow.focus()
+  }
+
   /* ****************************************************************************/
   // Querying
   /* ****************************************************************************/

--- a/src/main/WindowManager.js
+++ b/src/main/WindowManager.js
@@ -11,6 +11,7 @@ class WindowManager {
 
   /**
   * @param mailboxesWindow: the main window
+  * @param appSettings: the app settings
   */
   constructor (mailboxesWindow, appSettings) {
     this.contentWindows = []

--- a/src/main/WindowManager.js
+++ b/src/main/WindowManager.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const app = require('app')
+const AppSettings = require('./AppSettings')
 
 class WindowManager {
 
@@ -11,9 +12,10 @@ class WindowManager {
   /**
   * @param mailboxesWindow: the main window
   */
-  constructor (mailboxesWindow) {
+  constructor (mailboxesWindow, appSettings) {
     this.contentWindows = []
     this.mailboxesWindow = mailboxesWindow
+    this.appSettings = appSettings
     this.forceQuit = false
     this.mailboxesWindow.on('close', (e) => this.handleClose(e))
     this.mailboxesWindow.on('closed', () => {
@@ -33,7 +35,7 @@ class WindowManager {
   handleClose (evt) {
     if (this.focused() && !this.forceQuit) {
       this.contentWindows.forEach((w) => w.close())
-      if (process.platform === 'darwin') {
+      if (process.platform === 'darwin' || this.appSettings.loadValue('showTrayIcon')) {
         this.mailboxesWindow.hide()
         evt.preventDefault()
         this.forceQuit = false

--- a/src/main/WindowManager.js
+++ b/src/main/WindowManager.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const app = require('app')
-const AppSettings = require('./AppSettings')
 
 class WindowManager {
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -27,7 +27,7 @@ const localStorage = new LocalStorage(appDirectory.userData())
 const appSettings = new AppSettings(localStorage)
 const analytics = new AppAnalytics(localStorage, appSettings)
 const mailboxesWindow = new MailboxesWindow(analytics, localStorage, appSettings)
-const windowManager = new WindowManager(mailboxesWindow)
+const windowManager = new WindowManager(mailboxesWindow, appSettings)
 
 const appMenuSelectors = {
   fullQuit: () => { windowManager.quit() },
@@ -130,9 +130,7 @@ app.on('ready', () => {
 })
 
 app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  app.quit()
 })
 
 app.on('activate', function () {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -103,6 +103,10 @@ ipcMain.on('new-window', (evt, body) => {
   window.start(body.url, body.partition)
 })
 
+ipcMain.on('focus-app', (evt, body) => {
+  windowManager.focusMailboxesWindow()
+})
+
 ipcMain.on('restart-app', (evt, body) => {
   exec('"' + process.execPath.replace(/\"/g, '\\"') + '"')
   windowManager.quit()


### PR DESCRIPTION
This fixes #109, and the first item of #75. This also fixes a bug that I found where sometimes the tray would not appear on app start even if the option was on. (I didn't test this thoroughly to see what caused it, I just forced it to apply settings on initial load in App.js.)

Let me know if there's anything you would prefer me to do differently!