### PR TITLE
Remove white background behind account icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fs-extra": "^0.26.7",
     "googleapis": "^4.0.0",
     "https-proxy-agent": "^1.0.0",
-    "material-ui": "^0.15.0-alpha.2",
+    "material-ui": "0.15.0-alpha.2",
     "minivents": "^2.0.1",
     "node-fetch": "^1.4.1",
     "nodehun": "^2.0.10",

--- a/src/mailbox/ui/Sidelist/mailboxListItem.less
+++ b/src/mailbox/ui/Sidelist/mailboxListItem.less
@@ -81,7 +81,6 @@
 			******************************************************/
 			&[data-type="ginbox"] {
 				&.active, &:hover { border-color: @INBOX_PRIM_COL; }
-				&.avatar { background-color: white; }
 				&.index {
 					background-color: @INBOX_PRIM_COL;
 					&.active, &:hover { border-color: @INBOX_SEC_COL; }
@@ -91,7 +90,6 @@
 
 			&[data-type="gmail"] {
 				&.active, &:hover { border-color: @GMAIL_PRIM_COL; }
-				&.avatar { background-color: white; }
 				&.index {
 					background-color: @GMAIL_PRIM_COL;
 					&.active, &:hover { border-color: @GMAIL_SEC_COL; }


### PR DESCRIPTION
The white background color causes a weird outline between the borders
and images in the mailbox list. Removing these declarations makes them
look as expected.

Additionally the material-ui package was pinned to 0.15.0-alpha.2,
because the one it currently resolves to is 0.15.0-beta.2, which has
dependency issues with react and react plugins/components.

Comparison of UI changes:

Before:
<img width="90" alt="screen shot 2016-04-22 at 4 53 47 pm" src="https://cloud.githubusercontent.com/assets/403961/14755923/457bf0b2-08ab-11e6-868c-ff67c1f9ec25.png">

After:
<img width="85" alt="screen shot 2016-04-22 at 4 53 54 pm" src="https://cloud.githubusercontent.com/assets/403961/14755927/49566fbe-08ab-11e6-86e4-20286cd044da.png">
