### PR TITLE
add cmd/ctrl + { and } keyboard shortcuts

### DIFF
--- a/src/app/src/app/KeyboardShortcuts.js
+++ b/src/app/src/app/KeyboardShortcuts.js
@@ -1,0 +1,49 @@
+const {globalShortcut} = require('electron')
+
+/*
+ * KeyboardShortcuts registers additional keyboard shortcuts.
+ * Note that most keyboard shortcuts are configured with the AppPrimaryMenu.
+ */
+class KeyboardShortcuts {
+
+  /* ****************************************************************************/
+  // Lifecycle
+  /* ****************************************************************************/
+
+  constructor (selectors) {
+    this._selectors = selectors
+    this._shortcuts = []
+  }
+
+  /* ****************************************************************************/
+  // Creating
+  /* ****************************************************************************/
+
+  /**
+   * Registers global keyboard shortcuts.
+   */
+  register () {
+    let shortcuts = new Map([
+      ['CmdOrCtrl+{', this._selectors.prevMailbox],
+      ['CmdOrCtrl+}', this._selectors.nextMailbox]
+    ])
+    this.unregister()
+    shortcuts.forEach((callback, accelerator) => {
+      globalShortcut.register(accelerator, callback)
+      this._shortcuts.push(accelerator)
+    })
+  }
+
+  /**
+   * Unregisters any previously registered global keyboard shortcuts.
+   */
+  unregister () {
+    this._shortcuts.forEach((accelerator) => {
+      globalShortcut.unregister(accelerator)
+    })
+    this._shortcuts = []
+  }
+
+}
+
+module.exports = KeyboardShortcuts


### PR DESCRIPTION
converting from Chrome to WMail, I found myself relying on the Chrome tab switching shortcuts which use { and } rather than < and >.

this pull request introduces a `KeyboardShortcuts` class with just the alias for the mailbox switching calls configured. it should also make adding more shortcuts easy.

thanks for your awesome work and I hope this helps!