### PR TITLE
Add a tooltip to sleepable

### DIFF
--- a/src/scenes/mailboxes/src/ui/Settings/Accounts/AccountServiceSettings.js
+++ b/src/scenes/mailboxes/src/ui/Settings/Accounts/AccountServiceSettings.js
@@ -115,7 +115,9 @@ module.exports = React.createClass({
             <TableRow>
               <TableHeaderColumn style={serviceStyles.actionCell} />
               <TableHeaderColumn style={serviceStyles.titleCell}>Service</TableHeaderColumn>
-              <TableHeaderColumn style={serviceStyles.actionCell}>Sleepable</TableHeaderColumn>
+              <TableHeaderColumn style={serviceStyles.actionCell} tooltip="Allows services to sleep to reduce memory consumption">
+                Sleepable
+              </TableHeaderColumn>
               <TableHeaderColumn style={serviceStyles.actionCell} />
               <TableHeaderColumn style={serviceStyles.actionCell} />
               <TableHeaderColumn style={serviceStyles.actionCell} />


### PR DESCRIPTION
Add a tooltip to "Sleepable" column header to explain it more. Used the material-ui docs to find it.

I tried running wmail locally to test it but couldn't figure it out.