### PR TITLE
Add options for tray icon behavior

### DIFF
--- a/src/app/src/app/main.js
+++ b/src/app/src/app/main.js
@@ -181,6 +181,10 @@
     windowManager.toggleMailboxWindowVisibilityFromTray()
   })
 
+  ipcMain.on('show-mailbox-from-tray', (evt, body) => {
+    windowManager.showMailboxWindowFromTray()
+  })
+
   ipcMain.on('quit-app', (evt, body) => {
     windowManager.quit()
   })

--- a/src/app/src/app/windows/WMailWindow.js
+++ b/src/app/src/app/windows/WMailWindow.js
@@ -74,6 +74,15 @@ class WMailWindow extends EventEmitter {
       this.window.on('maximize', (evt) => { this.saveWindowScreenLocation() })
       this.window.on('unmaximize', (evt) => { this.saveWindowScreenLocation() })
     }
+
+    this.window.on('minimize', (evt) => {
+      if (settingStore.tray.hideWhenMinimized) {
+        this.window.hide()
+
+        evt.preventDefault()
+      }
+    })
+
     this[settingStore.ui.showAppMenu ? 'showAppMenu' : 'hideAppMenu']()
 
     // Bind to change events

--- a/src/app/src/app/windows/WindowManager.js
+++ b/src/app/src/app/windows/WindowManager.js
@@ -32,7 +32,7 @@ class WindowManager {
   handleClose (evt) {
     if (!this.forceQuit) {
       this.contentWindows.forEach((w) => w.close())
-      if (process.platform === 'darwin' || settingStore.tray.show) {
+      if (process.platform === 'darwin' || (settingStore.tray.show && settingStore.tray.hideWhenClosed)) {
         this.mailboxesWindow.hide()
         evt.preventDefault()
         this.forceQuit = false
@@ -124,6 +124,14 @@ class WindowManager {
         this.mailboxesWindow.focus()
       }
     }
+  }
+
+  /**
+  * Shows and focuses the mailboxes window
+  */
+  showMailboxWindowFromTray () {
+    this.mailboxesWindow.show()
+    this.mailboxesWindow.focus()
   }
 
   /* ****************************************************************************/

--- a/src/scenes/mailboxes/src/stores/settings/settingsActions.js
+++ b/src/scenes/mailboxes/src/stores/settings/settingsActions.js
@@ -290,6 +290,48 @@ class SettingsActions {
     return this.update(SEGMENTS.TRAY, 'dpiMultiplier', parseInt(val))
   }
 
+  /**
+  * @param enabled: true to hide the window when minimized, false otherwise
+  */
+  setHideWhenMinimized (enabled) {
+    return this.update(SEGMENTS.TRAY, 'hideWhenMinimized', enabled)
+  }
+
+  /**
+  * Toggles whether to hide when minimized
+  */
+  toggleHideWhenMinimized () {
+    return this.toggle(SEGMENTS.TRAY, 'hideWhenMinimized')
+  }
+
+  /**
+  * @param enabled: true to hide the window when closed, false otherwise
+  */
+  setHideWhenClosed (enabled) {
+    return this.update(SEGMENTS.TRAY, 'hideWhenClosed', enabled)
+  }
+
+  /**
+  * Toggles whether to hide when closed
+  */
+  toggleHideWhenClosed () {
+    return this.toggle(SEGMENTS.TRAY, 'hideWhenClosed')
+  }
+
+  /**
+  * @param val: the mouse clicks that will trigger the action
+  */
+  setMouseTrigger (val) {
+    return this.update(SEGMENTS.TRAY, 'mouseTrigger', parseInt(val))
+  }
+
+  /**
+  * @param val: the action to take when the mouse is triggered
+  */
+  setMouseTriggerAction (val) {
+    return this.update(SEGMENTS.TRAY, 'mouseTriggerAction', parseInt(val))
+  }
+
   /* **************************************************************************/
   // News
   /* **************************************************************************/

--- a/src/scenes/mailboxes/src/ui/Settings/General/TraySettingsSection.js
+++ b/src/scenes/mailboxes/src/ui/Settings/General/TraySettingsSection.js
@@ -5,6 +5,7 @@ const settingsActions = require('../../../stores/settings/settingsActions')
 const styles = require('../settingStyles')
 const shallowCompare = require('react-addons-shallow-compare')
 const Tray = require('../../Tray')
+const constants = require('../../../../../../shared/constants')
 
 module.exports = React.createClass({
   /* **************************************************************************/
@@ -42,9 +43,44 @@ module.exports = React.createClass({
             labelPosition='right'
             disabled={!tray.show}
             onToggle={(evt, toggled) => settingsActions.setShowTrayUnreadCount(toggled)} />
+          <Toggle
+            toggled={tray.hideWhenClosed}
+            disabled={!tray.show}
+            label='Hide main window when closed'
+            labelPosition='right'
+            onToggle={(evt, toggled) => { settingsActions.setHideWhenClosed(toggled) }} />
+          <Toggle
+            toggled={tray.hideWhenMinimized}
+            disabled={!tray.show}
+            label='Hide main window when minimized'
+            labelPosition='right'
+            onToggle={(evt, toggled) => { settingsActions.setHideWhenMinimized(toggled) }} />
+          {Tray.platformSupportsDoubleClick() ? (
+            <SelectField
+              fullWidth
+              floatingLabelText='Mouse trigger'
+              disabled={!tray.show}
+              onChange={(evt, index, value) => settingsActions.setMouseTrigger(value)}
+              value={tray.mouseTrigger}>
+              <MenuItem value={constants.MOUSE_TRIGGERS.SINGLE} primaryText='Single click' />
+              <MenuItem value={constants.MOUSE_TRIGGERS.DOUBLE} primaryText='Double click' />
+            </SelectField>
+          ) : undefined }
+          {Tray.platformSupportsDoubleClick() ? (
+            <SelectField
+              fullWidth
+              floatingLabelText='Mouse action'
+              disabled={!tray.show}
+              onChange={(evt, index, value) => settingsActions.setMouseTriggerAction(value)}
+              value={tray.mouseTriggerAction}>
+              <MenuItem value={constants.MOUSE_TRIGGER_ACTIONS.TOGGLE} primaryText='Toggle window visibility' />
+              <MenuItem value={constants.MOUSE_TRIGGER_ACTIONS.SHOW} primaryText='Show window' />
+            </SelectField>
+          ) : undefined }
           {Tray.platformSupportsDpiMultiplier() ? (
             <SelectField
               floatingLabelText='DPI Multiplier'
+              disabled={!tray.show}
               value={tray.dpiMultiplier}
               onChange={(evt, index, value) => settingsActions.setDpiMultiplier(value)}>
               <MenuItem value={1} primaryText='1x' />

--- a/src/scenes/mailboxes/src/ui/Tray.js
+++ b/src/scenes/mailboxes/src/ui/Tray.js
@@ -9,6 +9,7 @@ const { BLANK_PNG } = require('shared/b64Assets')
 const { TrayRenderer } = require('../Components')
 const navigationDispatch = require('../Dispatch/navigationDispatch')
 const uuid = require('uuid')
+const constants = require('../../../../shared/constants')
 
 module.exports = React.createClass({
   /* **************************************************************************/
@@ -24,6 +25,9 @@ module.exports = React.createClass({
   statics: {
     platformSupportsDpiMultiplier: () => {
       return process.platform === 'darwin' || process.platform === 'linux'
+    },
+    platformSupportsDoubleClick: () => {
+      return process.platform === 'win32' || process.platform === 'darwin'
     }
   },
 
@@ -37,10 +41,14 @@ module.exports = React.createClass({
     this.appTray = new Tray(nativeImage.createFromDataURL(BLANK_PNG))
     if (process.platform === 'win32') {
       this.appTray.on('double-click', () => {
-        ipcRenderer.send('toggle-mailbox-visibility-from-tray')
+        if (this.props.traySettings.mouseTrigger === constants.MOUSE_TRIGGERS.DOUBLE) {
+          ipcRenderer.send(this.props.traySettings.mouseTriggerAction === constants.MOUSE_TRIGGER_ACTIONS.TOGGLE ? 'toggle-mailbox-visibility-from-tray' : 'show-mailbox-from-tray')
+        }
       })
       this.appTray.on('click', () => {
-        ipcRenderer.send('toggle-mailbox-visibility-from-tray')
+        if (this.props.traySettings.mouseTrigger === constants.MOUSE_TRIGGERS.SINGLE) {
+          ipcRenderer.send(this.props.traySettings.mouseTriggerAction === constants.MOUSE_TRIGGER_ACTIONS.TOGGLE ? 'toggle-mailbox-visibility-from-tray' : 'show-mailbox-from-tray')
+        }
       })
     } else if (process.platform === 'linux') {
       // On platforms that have app indicator support - i.e. ubuntu clicking on the

--- a/src/shared/Models/Settings/TraySettings.js
+++ b/src/shared/Models/Settings/TraySettings.js
@@ -1,4 +1,5 @@
 const Model = require('../Model')
+const constants = require('../../../shared/constants')
 
 class TraySettings extends Model {
 
@@ -21,6 +22,10 @@ class TraySettings extends Model {
 
   get show () { return this._value_('show', true) }
   get showUnreadCount () { return this._value_('showUnreadCount', true) }
+  get mouseTrigger () { return this._value_('mouseTrigger', constants.MOUSE_TRIGGERS.SINGLE) }
+  get mouseTriggerAction () { return this._value_('mouseTriggerAction', constants.MOUSE_TRIGGER_ACTIONS.TOGGLE) }
+  get hideWhenMinimized () { return this._value_('hideWhenMinimized', false) }
+  get hideWhenClosed () { return this._value_('hideWhenClosed', true) }
   get readColor () { return this._value_('readColor', this.__themedDefaults__.readColor) }
   get readBackgroundColor () { return this._value_('readBackgroundColor', this.__themedDefaults__.readBackgroundColor) }
   get unreadColor () { return this._value_('unreadColor', this.__themedDefaults__.unreadColor) }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -21,5 +21,15 @@ module.exports = Object.freeze({
   REFOCUS_MAILBOX_INTERVAL_MS: 300,
 
   DB_EXTENSION: 'wmaildb',
-  DB_WRITE_DELAY_MS: 500 // 0.5secs
+  DB_WRITE_DELAY_MS: 500, // 0.5secs
+
+  MOUSE_TRIGGERS: {
+    SINGLE: 0,
+    DOUBLE: 1
+  },
+
+  MOUSE_TRIGGER_ACTIONS: {
+    TOGGLE: 0,
+    SHOW: 1
+  }
 })


### PR DESCRIPTION
I'm used to slightly different behavior for applications with a tray icon:

1. Hiding when the window is minimized rather than when it is closed
1. Showing menu with a double click on the tray icon rather than a single click

I added some options to allow this but preserving the current defaults:

- "Hide main window when minimized" - defaults to off
- "Hide main window when closed" - defaults to on
- "Mouse trigger" - default to single click - has option for double click
- "Mouse action" - defaults to "toggle window visibility" - has option for "show window"

The mouse options (trigger/action) are hidden on Linux since there's no double click for the tray icon.

I tested on Windows and Linux but don't have a Mac system to test on.

Thanks!